### PR TITLE
Make button_ghost transparent

### DIFF
--- a/catppuccin.user.css
+++ b/catppuccin.user.css
@@ -156,4 +156,8 @@
   svg {
     --geist-stroke: var(--geist-background) !important;
   }
+  
+  .button_ghost__sBWMh {
+    --lighten-color: transparent !important;
+  }
 }


### PR DESCRIPTION
Makes button_ghost transparent (because Vercel gives it a background color by default for some reason).

(arrows to the right of dropdown selection)
![button_ghost changed example](https://cdn.upload.systems/uploads/Wow8LXNQ.png)